### PR TITLE
Remove non-compilable FFT demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ QUARTUS_HDL_SOURCE = $(wildcard src/*.v) $(wildcard src/*.vhd) $(wildcard src/*.
 QUARTUS_MISC_SOURCE = $(wildcard src/*.stp) $(wildcard src/*.sdc)
 PROJECT_ASSIGN_SCRIPTS = $(filter scripts/create_ghrd_quartus_%.tcl,$(TCL_SOURCE))
 
-QSYS_ADD_COMP_TCLS := $(sort $(wildcard scripts/qsys_add_*.tcl))
+QSYS_ADD_COMP_TCLS := $(sort $(filter-out\
+ %_fft128_components.tcl,$(wildcard scripts/qsys_add_*.tcl)))
 
 #UBOOT_PATCHES = patches/soc_workshop_uboot_patch.patch patches/soc_workshop_uboot_patch_2.patch
 LINUX_BRANCH ?= socfpga-3.10-ltsi

--- a/mks/quartus.mk
+++ b/mks/quartus.mk
@@ -61,7 +61,6 @@ $$(QUARTUS_SOF_$1): $$(QUARTUS_STAMP_$1)
 $$(QUARTUS_JDI_$1): $$(QUARTUS_STAMP_$1)
 
 $$(QUARTUS_STAMP_$1): $$(QUARTUS_DEPS_$1)
-	quartus_stp $$(QUARTUS_QPF_$1) -c $1 2>&1 | tee logs/$$(notdir $$@).log
 	quartus_sh --flow compile $$(QUARTUS_QPF_$1) -c $1 2>&1 | tee -a logs/$$(notdir $$@).log
 	$$(stamp_target)	
 	

--- a/scripts/atlas_socdk_setup_angstrom_1.7.sh
+++ b/scripts/atlas_socdk_setup_angstrom_1.7.sh
@@ -38,6 +38,15 @@ echo "SSTATE_DIR = \"\${TOPDIR}/../ang_sstate_cache\"" >> setup-scripts/conf/sit
 # this qemu doesnt build with gcc5
 rm setup-scripts/sources/meta-linaro/meta-linaro/recipes-devtools/qemu/qemu_git.bb
 
+# Patch build to remove errors
+cat <<"EOF" >>setup-scripts/conf/local.conf
+
+# Skip non-compilable package
+IMAGE_INSTALL_remove_pn-atlas-soc-image     = "atlas-soc-fftsw-apps"
+IMAGE_INSTALL_remove_pn-atlas-soc-image     = "atlas-soc-fftsw-apps-init"
+IMAGE_INSTALL_remove_pn-atlas-soc-image     = "atlas-soc-fftsw-apps-src"
+EOF
+
 cd setup-scripts
 source environment-angstrom-v2014.12
 


### PR DESCRIPTION
The FFT demo is not compilable at two different positions, for two different reasons:
1. the FPGA code does not compile on a free Quartus installation because an OpenCores FFT license is missing. This is probably no problem for users of a full Quartus license.
2. the FFT demo application (software) cannot be build by bitbake. Apparently some external tools are required that are not made available by bitbake.

This set of patches removes both features, leaving that part of the demo non-functional. But at least the user can compile an image that demos all other features...
